### PR TITLE
Adding error checks

### DIFF
--- a/R/iehfc_app.R
+++ b/R/iehfc_app.R
@@ -10,7 +10,7 @@
       
       req_packages <- c(
           "pacman", "shiny", "dplyr", "tidyr", "purrr", "ggplot2", "janitor", "data.table", "DT",
-          "remotes", "bsicons", "shinydashboard", "shinyjs", "markdown", "shinyFeedback",
+          "remotes", "bsicons", "shinydashboard", "shinyjs", "markdown",
           "htmlwidgets", "plotly"
       )
       

--- a/R/iehfc_app.R
+++ b/R/iehfc_app.R
@@ -10,8 +10,8 @@
       
       req_packages <- c(
           "pacman", "shiny", "dplyr", "tidyr", "purrr", "ggplot2", "janitor", "data.table", "DT",
-          "remotes", "bsicons", "shinydashboard", "shinyjs", "markdown", "htmlwidgets", "webshot",
-          "plotly", "bslib"
+          "remotes", "bsicons", "shinydashboard", "shinyjs", "markdown", "shinyFeedback",
+          "htmlwidgets", "plotly"
       )
       
       if(sum(req_packages %in% (.packages())) != length(req_packages)) { # Means we need to run global.R to get packages, otherwise we're fine

--- a/iehfc_app/global.R
+++ b/iehfc_app/global.R
@@ -11,9 +11,6 @@
       shinydashboard, shinyjs, markdown, htmlwidgets, webshot, plotly, bslib
   )
   
-  remotes::install_github("merlinoa/shinyFeedback", ref = "feature/loadingButton_icon")
-  library(shinyFeedback)
-  
   
   ## 2. Load Custom Functions ----
 

--- a/iehfc_app/global.R
+++ b/iehfc_app/global.R
@@ -11,6 +11,9 @@
       shinydashboard, shinyjs, markdown, htmlwidgets, webshot, plotly, bslib
   )
   
+  remotes::install_github("merlinoa/shinyFeedback", ref = "feature/loadingButton_icon")
+  library(shinyFeedback)
+  
   
   ## 2. Load Custom Functions ----
 

--- a/iehfc_app/iehfc_server.R
+++ b/iehfc_app/iehfc_server.R
@@ -74,7 +74,7 @@
       
       output$upload_tab_data <- renderUI({
           layout_column_wrap(
-              height = "85vh",
+              height = "120vh",
               width = 1,
               card(
                   card_header(
@@ -116,7 +116,8 @@
               "use_test_data",
               "Use Test Data",
               icon("table"),
-              class = "btn btn-outline-primary btn-lg"
+              class = "btn btn-outline-primary btn-lg",
+              width = "100%"
           )
       })
       
@@ -795,11 +796,13 @@
       })
       
       output$setup_run_hfcs_button <- renderUI({
-          actionButton(
-              "run_hfcs",
-              "RUN HFCs",
-              icon("paper-plane"),
-              class = "btn btn-outline-primary btn-lg"
+          loadingButton(
+              inputId      = "run_hfcs",
+              label        = "RUN HFCs",
+              class        = "btn btn-lg btn-outline-primary",
+              icon         = icon("paper-plane"),
+              style        = "width: 100%;",
+              loadingLabel = ""
           )
       })
       
@@ -807,6 +810,13 @@
       
       observeEvent(input$run_hfcs, {
           updateNavbarPage(session, "tabs", selected = "output_tab")
+          Sys.sleep(1)
+          resetLoadingButton("run_hfcs")
+          showNotification(
+              "HFCs were successully run. Please click on the \"Outputs\" tab.",
+              duration = 4,
+              type     = "message"
+          )
       })
       
       output$setup_tab_data <- renderUI({

--- a/iehfc_app/iehfc_server.R
+++ b/iehfc_app/iehfc_server.R
@@ -36,12 +36,21 @@
       hfc_dataset <- reactiveVal()
       
       observeEvent(input$hfc_file, {
-          ds <- read.csv(hfc_file()$datapath, na.strings = c("", "NA"))
+          ds <- fread(hfc_file()$datapath, na.strings = c("", "NA_character_", "NA"))
+          too_many_cols <- ncol(ds) > 10000
+          if(too_many_cols) {
+              showNotification(
+                  "Your dataset has more than 10,000 variables. Unfortunately, the platform currently cannot handle such a large dataset. Please create a subset of your dataset and try again.",
+                  duration = NULL,
+                  type     = "error"
+              )
+          }
+          req(!too_many_cols)
           hfc_dataset(ds)
       })
       
       observeEvent(input$use_test_data, {
-          ds <- read.csv("test_data/LWH_FUP2_raw_data.csv", na.strings = "")
+          ds <- fread("test_data/LWH_FUP2_raw_data.csv", na.strings = "")
           hfc_dataset(ds)
       })
       

--- a/iehfc_app/iehfc_server.R
+++ b/iehfc_app/iehfc_server.R
@@ -805,13 +805,11 @@
       })
       
       output$setup_run_hfcs_button <- renderUI({
-          loadingButton(
-              inputId      = "run_hfcs",
-              label        = "RUN HFCs",
-              class        = "btn btn-lg btn-outline-primary",
-              icon         = icon("paper-plane"),
-              style        = "width: 100%;",
-              loadingLabel = ""
+          actionButton(
+              "run_hfcs",
+              "RUN HFCS",
+              icon("paper-plane"),
+              class = "btn btn-outline-primary btn-lg"
           )
       })
       
@@ -820,7 +818,6 @@
       observeEvent(input$run_hfcs, {
           updateNavbarPage(session, "tabs", selected = "output_tab")
           Sys.sleep(1)
-          resetLoadingButton("run_hfcs")
           showNotification(
               "HFCs were successully run. Please click on the \"Outputs\" tab.",
               duration = 4,

--- a/iehfc_app/iehfc_ui.R
+++ b/iehfc_app/iehfc_ui.R
@@ -15,31 +15,29 @@
 
   fluidPage(
       useShinyjs(),
-      navbarPage(
+      useShinyFeedback(),
+      page_navbar(
           title = "iehfc",
-          
-          # Initialize shinyjs
-          
-          tabPanel(
+          nav_panel(
               "Introduction",
               introduction_tab 
           ),
-          tabPanel(
+          nav_panel(
               "Upload Data",
               id = "upload_tab",  # Give an ID for reference
               uiOutput("upload_tab")
           ),
-          tabPanel(
+          nav_panel(
               "Check Selection and Setup",
               id = "setup_tab",  # Give an ID for reference
               uiOutput("setup_tab")
           ),
-          tabPanel(
+          nav_panel(
               "Outputs",
               id = "output_tab",  # Give an ID for reference
               uiOutput("output_tab")
           ),
-          navbarMenu("More",
+          nav_menu("More",
                      tabPanel(tags$a("Guides", href = "https://github.com/dime-worldbank/iehfc/blob/main/README.md")),
                      # tabPanel(tags$a("About", href = "https://www.github.com")), # Under construction
                      tabPanel(tags$a("Github", href = "https://www.github.com/dime-worldbank/iehfc"))
@@ -59,8 +57,17 @@
                   body {
                       font-size: 16px;
                   }
+                  
+                  .nav-link {
+                      font-size: 18px;
+                  }
+                  
+                  .shiny-notification {
+                       position:fixed;
+                       right: calc(65%);
+                  }
                   "
-              )
+              ) # Source: https://stackoverflow.com/questions/44112000/move-r-shiny-shownotification-to-center-of-screen
       )
       
   )

--- a/iehfc_app/iehfc_ui.R
+++ b/iehfc_app/iehfc_ui.R
@@ -15,7 +15,6 @@
 
   fluidPage(
       useShinyjs(),
-      useShinyFeedback(),
       page_navbar(
           title = "iehfc",
           nav_panel(


### PR DESCRIPTION
Built on top of 'develop' branch. Would recommend merging into there once changes have been reviewed.

Changes made:
- Changed `read.csv()` to `data.table::fread()`. It was taking too long to load in large data frames.
- Added first error check + notification on platform: when a data frame is too large. Currently, the arbitrary limit is 10,000 variables, but it can be changed. To implement this changed, I used the `req()` and `showNotification()` functions from the `shiny` package, so didn't have to add any packages.
- While looking into how to implement error checks, I stumbled upon a method to add a loading widget to the "Run HFCs" button. It uses the `loadingButton()` function from the `shinyValidate` package. I'm a little uncertain about using it because the package only works with the GitHub-repository version, and it only works as I would like (with the paper-plane icon) using a branch from the GitHub repo. I've reached out to the creators to see if they'll merge this (useful) branch into their `main` branch so that at least we can load the main repo.

Next steps:
- I believe that this check is sufficient for now in terms of loading data. So it can be merged (as well as the two other changes listed above) with the `main` branch and presented during MSFR.
- Implement error checks and notifications elsewhere. Realistically, the large majority of the remaining checks will be occurring after clicking on the "Run HFCs" button. `showNotification()` would work within the `observeEvent()` chunk of code for "Run HFCs" and might have a lot of checks in it. I'm thinking about how to implement this in the code in an efficient manner; it would probably be best to move this `observeEvent()` into a separate script. Still thinking if there's a better method than that. Open to suggestions!

