### PR TITLE
Introduce the ability to assign the id variable universally

### DIFF
--- a/iehfc_app/iehfc_server.R
+++ b/iehfc_app/iehfc_server.R
@@ -1017,7 +1017,7 @@
                       column(6,
                              span("Unit of Observation", bsicons::bs_icon("question-circle-fill")) %>%
                                  tooltip(
-                                     "This is the variable that identifies the unit of observation for each submission",
+                                     "This is the variable that identifies the unit of observation for each submission.Such variable could be the Dataset ID.",
                                      placement = "right"
                                  ),
                              uiOutput("unit_var_select", style = "z-index: 1000;") # Set a high z-index to overlap other elements
@@ -1118,15 +1118,15 @@
           }
           
           ## Duplicates
-          if (!is.null(input$duplicate_select_var)) {
-              para1 <- data.frame(Check = "duplicate",
-                                  Parameter = "duplicate_select_var", 
-                                  Name = "Duplicates ID variable", 
-                                  Value = c(input$duplicate_select_var),
-                                  Timestamp = format(current_datetime, format = "%d-%b-%Y %I:%M %p"))
-              combined_df <- rbind(combined_df, para1)
-          }
-          
+          # if (!is.null(input$duplicate_select_var)) {
+          #     para1 <- data.frame(Check = "duplicate",
+          #                         Parameter = "duplicate_select_var", 
+          #                         Name = "Duplicates ID variable", 
+          #                         Value = c(input$duplicate_select_var),
+          #                         Timestamp = format(current_datetime, format = "%d-%b-%Y %I:%M %p"))
+          #     combined_df <- rbind(combined_df, para1)
+          # }
+          # 
           if (!is.null(input$duplicate_extra_vars_select_var)) {
               para2 <- data.frame(Check = "duplicate",
                                   Parameter = "duplicate_extra_vars_select_var", 
@@ -1155,19 +1155,11 @@
               combined_df <- rbind(combined_df, para4)
           }
           
-          if (!is.null(input$outlier_id_select_var)) {
-              para5 <- data.frame(Check = "outlier",
-                                  Parameter = "outlier_id_select_var", 
-                                  Name = "Outlier ID variable", 
-                                  Value = c(input$outlier_id_select_var),
-                                  Timestamp = format(current_datetime, format = "%d-%b-%Y %I:%M %p"))
-              combined_df <- rbind(combined_df, para5)
-          }
           
           if (!is.null(input$outlier_extra_vars_select_var)) {
               para5 <- data.frame(Check = "outlier",
                                   Parameter = "outlier_extra_vars_select_var", 
-                                  Name = "Outlier ID variable", 
+                                  Name = "Outlier additional variables", 
                                   Value = c(input$outlier_extra_vars_select_var),
                                   Timestamp = format(current_datetime, format = "%d-%b-%Y %I:%M %p"))
               combined_df <- rbind(combined_df, para5)

--- a/iehfc_app/iehfc_server.R
+++ b/iehfc_app/iehfc_server.R
@@ -162,7 +162,7 @@
       
       ## Setup Tab ----
       
-        ### Read from imported parameters
+      ### Read from imported parameters
       
       parameter_file <- reactive({
           input$parameter_file
@@ -175,9 +175,61 @@
           imported_para_dataset(para_ds)
       })
       
+      ### Select ID Variable ----
       
+      selected_id_var <- reactiveVal()
+      
+      observe({
+          id_var_imported <- imported_para_dataset()[imported_para_dataset()$Parameter == "id_select_var", "Value"]
+          if (!is.null(id_var_imported)) {
+              selected_id_var(id_var_imported)
+              updateSelectizeInput(session, "id_select_var", selected = id_var_imported)
+          }
+      })
+      
+      observe({
+          selected_id_var(input$id_select_var)
+      })
+      
+      output$id_select <- renderUI({
+          selectizeInput(
+              "id_select_var", 
+              label = "ID Variable", 
+              choices = c("", hfc_dataset() %>% names()),
+              selected = "",
+              options = list(
+                  'dropdownParent' = 'body'
+              )
+          )
+      })
+      
+      observe({
+          updateSelectizeInput(session, "id_select_var", 
+                               choices = c("", hfc_dataset() %>% names()),
+                               selected = "")
+      })
+      
+      
+      observe({
+          if (!is.null(selected_id_var()) && selected_id_var() != "") {
+              updateActionButton(session, "run_hfcs", disabled = FALSE)
+              runjs("$('#run_hfcs').tooltip('hide')")
+          } else {
+              updateActionButton(session, "run_hfcs", disabled = TRUE)
+              runjs("$('#run_hfcs').tooltip('show')") 
+          }
+      })
+      
+      # Bring ID Variable from uploaded parameter dataset
+      observe({
+          id_select_var_imported <- 
+              imported_para_dataset()[imported_para_dataset()$Parameter == "id_select_var", "Value"]
+          if (!is.null(id_select_var_imported)) {
+              selected_id_var(id_select_var_imported)
+          }
+      })
    
-        ### Check Selection ----
+      ### Check Selection ----
       
       output$check_select <- renderUI({
           checkboxGroupInput(
@@ -209,27 +261,16 @@
           # Duplicate IDs
           # Additional variables for reference
       
-      current_duplicate_id_var     <- reactiveVal() # For storing current state of 'duplicate_id_select_var'
       current_duplicate_extra_vars <- reactiveVal() # For storing current state of 'duplicate_extra_vars_select_var'
       
       # Bring duplicate variables from uploaded parameter dataset
       observe({
-          duplicate_id_select_var_imported <- 
-              imported_para_dataset()[imported_para_dataset()$Parameter == "duplicate_id_select_var", "Value"]
-          if (!is.null(duplicate_id_select_var_imported)) {
-              current_duplicate_id_var(duplicate_id_select_var_imported)
-          }
-          
           duplicate_extra_vars_imported <- 
               imported_para_dataset()[imported_para_dataset()$Parameter == "duplicate_extra_vars_select_var", "Value"]
           if (!is.null(duplicate_extra_vars_imported)) {
               current_duplicate_extra_vars(duplicate_extra_vars_imported)
+              updateSelectizeInput(session, "duplicate_extra_vars_select_var", selected = duplicate_extra_vars_imported)
           }
-      })
-      
-      # Observe any change in 'duplicate_id_select_var' and update current_duplicate_id_var
-      observe({
-          current_duplicate_id_var(input$duplicate_id_select_var)
       })
       
       # Observe any change in 'duplicate_extra_vars_select_var' and update current_duplicate_extra_vars
@@ -237,60 +278,76 @@
           current_duplicate_extra_vars(input$duplicate_extra_vars_select_var)
       })
       
-      output$duplicate_id_select <- renderUI({
-          selectizeInput(
-              "duplicate_id_select_var", label = NULL, 
-              choices = hfc_dataset() %>% names,
-              selected = current_duplicate_id_var(),  # Preserve the selection
-              options = list('dropdownParent' = 'body')
-          )
-      })
+
+      #The code below is for a dropdown that allows the user to select extra variables for duplicate check. It is hidden in the UI because the functionality is not complete. 
       
-      observe({
-          updateSelectizeInput(session, "duplicate_id_select_var", 
-                               choices = hfc_dataset() %>% names,
-                               selected = current_duplicate_id_var())
-      })
+      # output$duplicate_select <- renderUI({
+      #     selectizeInput(
+      #         "duplicate_select_var", 
+      #         label = NULL, 
+      #         choices = character(0),  # Empty by default
+      #         selected = current_duplicate_var(),  # Preserve the selection if available
+      #         options = list('dropdownParent' = 'body')
+      #     )
+      # })
+      # 
+      # 
+      # observe({
+      #     # Update the selectizeInput only when hfc_dataset() is not NULL
+      #     if (!is.null(hfc_dataset())) {
+      #         updateSelectizeInput(session, "duplicate_select_var", 
+      #                              choices = hfc_dataset() %>%
+      #                                  select(-all_of(selected_id_var())) %>%
+      #                                  names(),
+      #                              selected = current_duplicate_var())
+      #     }
+      # })
       
       
       
       output$duplicate_extra_vars_select <- renderUI({
+          dataset <- hfc_dataset()
+          
+          if (!is.null(selected_id_var()) && selected_id_var() != "") {
+              dataset <- dataset %>%
+                  select(-all_of(selected_id_var()))
+          }
+          
+          # if (!is.null(current_duplicate_var()) && current_duplicate_var() != "") {
+                      #     dataset <- dataset %>%
+                      #         select(-all_of(current_duplicate_var()))  # exclude current_duplicate_var
+                      # }
+          
           selectizeInput(
-              "duplicate_extra_vars_select_var", label = NULL,
-              choices = hfc_dataset() %>%
-                  select(
-                      -all_of(duplicate_id_var()[duplicate_id_var() != ""]) # Everything but the ID variable
-                  ) %>%
-                  select( # Ensures that selection order is preserved
-                      all_of(duplicate_extra_vars()[duplicate_extra_vars() != ""]),
-                      !any_of(duplicate_extra_vars()[duplicate_extra_vars() != ""])
-                  ) %>%
-                  names(), 
+              "duplicate_extra_vars_select_var", 
+              label = NULL,
+              choices = names(dataset),
               selected = current_duplicate_extra_vars(),
               multiple = TRUE,
               options = list('dropdownParent' = 'body')
           )
       })
       
+      
       output$duplicate_setup <- renderUI({
           card(
-              height = "30vh", fill = FALSE,
+              height = "auto", fill = FALSE,
               full_screen = TRUE,
               card_header(
                   span("Duplicate Check Setup", bsicons::bs_icon("question-circle-fill")) %>%
                       tooltip(
-                          "The duplicate check requires you to provide the variable you want to check for duplicates. You can add any additional variable you want to include in the output table",
+                          "The duplicate check checks the Dataset ID for duplicates. You can add any additional variable you want to include in the output table",
                           placement = "auto"
                       )
               ),
               card_body(
                   fluidRow(
-                      column(6, 
-                             span("ID Variable", bsicons::bs_icon("question-circle-fill")) %>%
-                                 tooltip("This is the variable that you want to check for duplicates (usually an ID intended to be uniquely identified)", 
-                                         placement = "right"),
-                             uiOutput("duplicate_id_select", style = "z-index: 1000;")  # Set a high z-index to overlap other elements
-                      ),
+                      # column(6, 
+                      #        span("Extra Variable to Check", bsicons::bs_icon("question-circle-fill")) %>%
+                      #            tooltip("This is an optional variable that you might want to check for duplicates, besides,the ID. Duplicate IDs are checked automatically.", 
+                      #                    placement = "right"),
+                      #        uiOutput("duplicate_select", style = "z-index: 1000;")  # Set a high z-index to overlap other elements
+                      # ),
                       column(6,
                              span("Additional Variables", bsicons::bs_icon("question-circle-fill")) %>%
                                  tooltip("These are additional variables that you may want to feature in the output table", 
@@ -311,7 +368,6 @@
       
       current_indiv_outlier_vars <- reactiveVal() # For storing current state of 'indiv_outlier_vars_select_var'
       current_group_outlier_vars <- reactiveVal() # For storing current state of 'group_outlier_vars_select_var'
-      current_outlier_id_var     <- reactiveVal() # For storing current state of 'outlier_id_select_var'
       current_outlier_extra_vars <- reactiveVal() # For storing current state of 'outlier_extra_vars_select_var'
       current_outlier_method     <- reactiveVal() # For storing current state of 'outlier_method'
       current_outlier_multiplier <- reactiveVal() # For storing current state of 'outlier_multiplier'
@@ -327,14 +383,11 @@
           group_outlier_vars_select_var_imported <- 
               imported_para_dataset()[imported_para_dataset()$Parameter == "group_outlier_vars_select_var", "Value"]
           if (!is.null(group_outlier_vars_select_var_imported)) {
-              current_duplicate_extra_vars(group_outlier_vars_select_var_imported)
+              current_group_outlier_vars(group_outlier_vars_select_var_imported)
+              updateSelectizeInput(session, "group_outlier_vars_select_var", selected = group_outlier_vars_select_var_imported)
+              
           }
           
-          outlier_id_select_var_imported <- 
-              imported_para_dataset()[imported_para_dataset()$Parameter == "outlier_id_select_var", "Value"]
-          if (!is.null(outlier_id_select_var_imported)) {
-              current_outlier_id_var(outlier_id_select_var_imported)
-          }
           
           outlier_extra_vars_select_var_imported <- 
               imported_para_dataset()[imported_para_dataset()$Parameter == "outlier_extra_vars_select_var", "Value"]
@@ -366,10 +419,6 @@
           current_group_outlier_vars(input$group_outlier_vars_select_var)
       })
       
-      # Observe any change in 'indiv_outlier_vars_select_var' and update current_outlier_id_var
-      observe({
-          current_outlier_id_var(input$outlier_id_select_var)
-      })
       
       # Observe any change in 'indiv_outlier_vars_select_var' and update current_outlier_id_var
       observe({
@@ -391,7 +440,7 @@
               "indiv_outlier_vars_select_var", label = NULL,
               choices = hfc_dataset() %>%
                   select(
-                      -all_of(outlier_id_var()[outlier_id_var() != ""]) # Everything but the ID variable
+                      -all_of(selected_id_var()[selected_id_var() != ""]) # Everything but the ID variable
                   ) %>%
                   select( # Ensures that selection order is preserved
                       all_of(indiv_outlier_vars()[indiv_outlier_vars() != ""]),
@@ -409,10 +458,12 @@
       output$group_outlier_vars_select <- renderUI({
           selectizeInput(
               "group_outlier_vars_select_var", label = NULL,
-              choices = hfc_dataset() %>%
-                  select(
-                      -all_of(duplicate_id_var()[duplicate_id_var() != ""]) # Everything but the ID variable
-                  ) %>%
+              choices = {             dataset <- hfc_dataset()
+
+              if (!is.null(selected_id_var()) && selected_id_var() != "") {
+                  dataset <- dataset %>% select(-all_of(selected_id_var()))
+              }
+                  dataset %>%
                   names() %>%
                   tibble(var = .) %>%
                   filter(
@@ -425,35 +476,28 @@
                   filter(n() > 1) %>% # Only keep groups that have more than one variable, otherwise just use indiv
                   select(group) %>%
                   distinct() %>%
-                  pull(), 
+                  pull()}, 
               selected = current_group_outlier_vars(),
               multiple = TRUE,
               options = list('dropdownParent' = 'body')
           )
       })
       
-      output$outlier_id_select <- renderUI({
-          selectizeInput(
-              "outlier_id_select_var", label = NULL, 
-              choices = hfc_dataset() %>%
-                  names(), 
-              selected = current_outlier_id_var(),
-              options = list('dropdownParent' = 'body')
-          )
-      })
-      
-      observe({
-          updateSelectizeInput(session, "outlier_id_select_var", 
-                               choices = hfc_dataset() %>% names,
-                               selected = current_outlier_id_var())
-      })
+
+     
       
       output$outlier_extra_vars_select <- renderUI({
           selectizeInput(
               "outlier_extra_vars_select_var", label = NULL,
-              choices = hfc_dataset() %>%
+              choices = {
+                  dataset <- hfc_dataset()
+                  
+                  if (!is.null(selected_id_var()) && selected_id_var() != "") {
+                      dataset <- dataset %>% select(-all_of(selected_id_var()))
+                  }
+                  
+                  dataset %>%
                   select(
-                      -all_of(duplicate_id_var()[duplicate_id_var() != ""]), # Everything but the ID variable or outlier variables
                       -any_of(indiv_outlier_vars()),
                       -any_of(matches(paste0("^", group_outlier_vars(), "_{0,1}[0-9]+$")))
                   ) %>%
@@ -461,7 +505,7 @@
                       all_of(outlier_extra_vars()),
                       !any_of(outlier_extra_vars())
                   ) %>%
-                  names(), 
+                  names()},
               selected = current_outlier_extra_vars(),
               multiple = TRUE,
               options = list('dropdownParent' = 'body')
@@ -494,7 +538,7 @@
       
       output$outlier_setup <- renderUI({
           card(
-              height = "30vh", fill = FALSE,
+              height = "auto", fill = FALSE,
               full_screen = TRUE,
               card_header(
                   span("Outlier Check Setup", bsicons::bs_icon("question-circle-fill")) %>%
@@ -521,12 +565,6 @@
               ),
               card_body(
                   fluidRow(
-                      column(6, 
-                             span("ID Variable", bsicons::bs_icon("question-circle-fill")) %>%
-                                 tooltip("This is the dataset's ID variable", 
-                                         placement = "right"),
-                             uiOutput("outlier_id_select", style = "z-index: 1000;")  # Set a high z-index to overlap other elements
-                      ),
                       column(6,
                              span("Additional Variables", bsicons::bs_icon("question-circle-fill")) %>%
                                  tooltip("These are additional variables that you may want to include in the output table", 
@@ -975,16 +1013,16 @@
               card_header(
                   span("Unit of Observation Check Setup", bsicons::bs_icon("question-circle-fill")) %>%
                       tooltip(
-                          "Placeholder text",
+                          "The unit-of-observation-level check requires you to provide the variable that identifies the unit of observation.You can add any additional variable you want to include in the output table",
                           placement = "auto"
                       )
               ),
               card_body(
                   fluidRow(
                       column(6,
-                             span("Unit of Observation/ID Variable", bsicons::bs_icon("question-circle-fill")) %>%
+                             span("Unit of Observation", bsicons::bs_icon("question-circle-fill")) %>%
                                  tooltip(
-                                     "Placeholder text",
+                                     "This is the variable that identifies the unit of observation for each submission",
                                      placement = "right"
                                  ),
                              uiOutput("unit_var_select", style = "z-index: 1000;") # Set a high z-index to overlap other elements
@@ -992,7 +1030,7 @@
                       column(6,
                              span("Additional Variables", bsicons::bs_icon("question-circle-fill")) %>%
                                  tooltip(
-                                     "Placeholder text",
+                                     "These are additional variables that you might want to include in the output table",
                                      placement = "right"
                                  ),
                              uiOutput("unit_extra_vars_select", style = "z-index: 1000;") # Set a high z-index to overlap other elements
@@ -1019,7 +1057,7 @@
       
       setup_check_list <- reactive({
           if(length(selected_checks()) == 0) { # No checks selected
-              "Please select the high-frequency check(s) you would like to perform from the list in the sidebar."
+              "Please select the ID variable and the high-frequency check(s) you would like to perform from the list in the sidebar."
           } else {
               selected_checks() %>%
                   purrr::map(
@@ -1037,13 +1075,31 @@
       })
       
       output$setup_run_hfcs_button <- renderUI({
-          actionButton(
-              "run_hfcs",
-              "RUN HFCS",
-              icon("paper-plane"),
-              class = "btn btn-outline-primary btn-lg"
+          tagList(
+              tags$div(
+                  actionButton(
+                      "run_hfcs",
+                      "RUN HFCS",
+                      icon("paper-plane"),
+                      class = "btn btn-outline-primary btn-lg",
+                      disabled = if (is.null(selected_id_var()) || selected_id_var() == "") TRUE else FALSE  # Disable if no ID is selected
+                  )
+              )
           )
       })
+      
+      observe({
+          if (!is.null(selected_id_var()) && selected_id_var() != "") {
+              updateActionButton(session, "run_hfcs", disabled = FALSE)
+          } else {
+              updateActionButton(session, "run_hfcs", disabled = TRUE)
+          }
+      })
+
+
+
+      
+      
       
            ### Export parameters
    
@@ -1054,12 +1110,24 @@
           
           # Check if each parameter is selected and add it to the combined data frame
           
+          ## ID Variable
+          
+          if (!is.null(input$id_select_var)) {
+              para2 <- data.frame(Check = "",
+                                  Parameter = "id_select_var", 
+                                  Name = "ID Variable", 
+                                  Value = c(input$id_select_var),
+                                  Timestamp = format(current_datetime, format = "%d-%b-%Y %I:%M %p"))
+              combined_df <-
+                  rbind(combined_df, para2)
+          }
+          
           ## Duplicates
-          if (!is.null(input$duplicate_id_select_var)) {
+          if (!is.null(input$duplicate_select_var)) {
               para1 <- data.frame(Check = "duplicate",
-                                  Parameter = "duplicate_id_select_var", 
+                                  Parameter = "duplicate_select_var", 
                                   Name = "Duplicates ID variable", 
-                                  Value = c(input$duplicate_id_select_var),
+                                  Value = c(input$duplicate_select_var),
                                   Timestamp = format(current_datetime, format = "%d-%b-%Y %I:%M %p"))
               combined_df <- rbind(combined_df, para1)
           }
@@ -1188,7 +1256,7 @@
           if (!is.null(input$unit_var_select_var)) {
               para14 <- data.frame(Check = "unit",
                                    Parameter = "unit_var_select_var", 
-                                   Name = "Unit of Observation/ID Variable", 
+                                   Name = "Unit of Observation", 
                                    Value = c(input$unit_var_select_var),
                                    Timestamp = format(current_datetime, format = "%d-%b-%Y %I:%M %p"))
               combined_df <- rbind(combined_df, para14)
@@ -1243,6 +1311,17 @@
                   width = "30%",
                   card(
                       card_header(
+                          
+                          span("Select Dataset ID", bsicons::bs_icon("question-circle-fill")) %>%
+                              tooltip(
+                                  "This is where you select the unique ID variable for your dataset obervations",
+                                  placement = "auto"
+                              )
+                      ),
+                      uiOutput("id_select")
+                  ),
+                  card(
+                      card_header(
                 
                           span("Data Quality Checks", bsicons::bs_icon("question-circle-fill")) %>%
                               tooltip(
@@ -1253,9 +1332,13 @@
                                   placement = "auto"
                               )
                       ),
-                      uiOutput("check_select")
+                      uiOutput("check_select"),
                   ),
-                  card(
+                  card(span("Run Checks", bsicons::bs_icon("question-circle-fill")) %>%
+                           tooltip(
+                               "Select an ID Variable to run checks.",
+                               placement = "auto"
+                           ),
                       uiOutput("setup_run_hfcs_button")
                   ),
                   card(span("Download Parameters", bsicons::bs_icon("question-circle-fill")) %>%

--- a/iehfc_app/server_scripts/duplicates.R
+++ b/iehfc_app/server_scripts/duplicates.R
@@ -1,27 +1,30 @@
 # Duplicate Data Quality Checks -- Construction ----
 
-  duplicate_id_var <- reactive({
-      input$duplicate_id_select_var
+  duplicate_var <- reactive({
+      input$duplicate_select_var
   })
   
   duplicate_extra_vars <- reactive({
       input$duplicate_extra_vars_select_var
   })
   
+
+
   duplicate_dataset <- reactive({
       hfc_dataset() %>%
-          group_by(!!sym(duplicate_id_var())) %>%
+          group_by(!!sym(selected_id_var())) %>%
           filter(n() > 1) %>%
           ungroup() %>%
           select(
               all_of(
-                  c(duplicate_id_var(), duplicate_extra_vars())
+                  c(selected_id_var(), duplicate_extra_vars())
               )
           )
   }) %>%
-  bindEvent(input$run_hfcs)
+      bindEvent(input$run_hfcs)
   
   output$duplicate_table <- renderDT(
       duplicate_dataset(), fillContainer = TRUE
   )
   
+ 

--- a/iehfc_app/server_scripts/outliers.R
+++ b/iehfc_app/server_scripts/outliers.R
@@ -33,11 +33,11 @@
       indiv_outlier_vars() %>%
           map(
               ~ hfc_dataset() %>%
-                  group_by(!!sym(outlier_id_var())) %>%
+                  group_by(!!sym(selected_id_var())) %>%
                   mutate(
-                      !!outlier_id_var() := case_when(
-                          n() > 1 ~ paste0(!!sym(outlier_id_var()), "_", row_number()),
-                          TRUE    ~ as.character(!!sym(outlier_id_var()))
+                      !!selected_id_var() := case_when(
+                          n() > 1 ~ paste0(!!sym(selected_id_var()), "_", row_number()),
+                          TRUE    ~ as.character(!!sym(selected_id_var()))
                       )
                   ) %>%
                   ungroup() %>%
@@ -92,9 +92,9 @@
                   
                 {
                   if (method == "sd") {
-                      select(., any_of(outlier_id_var()), any_of(outlier_extra_vars()), issue_var, value = matches(paste0("^", .x, "$")), mean, sd, low_limit, high_limit)
+                      select(., any_of(selected_id_var()), any_of(outlier_extra_vars()), issue_var, value = matches(paste0("^", .x, "$")), mean, sd, low_limit, high_limit)
                   } else {
-                      select(., any_of(outlier_id_var()), any_of(outlier_extra_vars()), issue_var, value = matches(paste0("^", .x, "$")), mean, iqr, low_limit, high_limit)
+                      select(., any_of(selected_id_var()), any_of(outlier_extra_vars()), issue_var, value = matches(paste0("^", .x, "$")), mean, iqr, low_limit, high_limit)
                   }
                 }
               
@@ -110,16 +110,16 @@
       group_outlier_vars() %>%
           map(
               ~ hfc_dataset() %>%
-                  group_by(!!sym(outlier_id_var())) %>%
+                  group_by(!!sym(selected_id_var())) %>%
                   mutate(
-                      !!outlier_id_var() := case_when(
-                          n() > 1 ~ paste0(!!sym(outlier_id_var()), "_", row_number()),
-                          TRUE    ~ as.character(!!sym(outlier_id_var()))
+                      !!selected_id_var() := case_when(
+                          n() > 1 ~ paste0(!!sym(selected_id_var()), "_", row_number()),
+                          TRUE    ~ as.character(!!sym(selected_id_var()))
                       )
                   ) %>%
                   ungroup() %>%
                   select(
-                      any_of(outlier_id_var()), any_of(outlier_extra_vars()), matches(paste0("^", .x, "_{0,1}[0-9]+$"))
+                      any_of(selected_id_var()), any_of(outlier_extra_vars()), matches(paste0("^", .x, "_{0,1}[0-9]+$"))
                   ) %>%
                   pivot_longer(
                       cols = matches(paste0("^", .x, "_{0,1}[0-9]+$")),
@@ -144,9 +144,9 @@
                   ) %>%
                   {
                       if (method == "sd") {
-                          select(., any_of(outlier_id_var()), any_of(outlier_extra_vars()), issue_var, value, mean, sd, low_limit, high_limit)
+                          select(., any_of(selected_id_var()), any_of(outlier_extra_vars()), issue_var, value, mean, sd, low_limit, high_limit)
                       } else {
-                          select(., any_of(outlier_id_var()), any_of(outlier_extra_vars()), issue_var, value, mean, iqr, low_limit, high_limit)
+                          select(., any_of(selected_id_var()), any_of(outlier_extra_vars()), issue_var, value, mean, iqr, low_limit, high_limit)
                       }
                   }
           ) %>%
@@ -156,7 +156,7 @@
   
   outlier_dataset <- reactive({
       bind_rows(indiv_outlier_dataset(), group_outlier_dataset()) %>%
-          arrange(!!sym(outlier_id_var()), issue_var)
+          arrange(!!sym(selected_id_var()), issue_var)
   }) %>%
   bindEvent(input$run_hfcs)
   


### PR DESCRIPTION
User can select id variable in the sidebar in the check selection tab.

HFCS cannot be run until ID variable is selected.

ID variable field was removed from Duplicate and Outlier checks cards.

ID variable is downloaded as csv with the rest of the parameters and can be reimported as per pre-existing behavior.

Updated all info tooltips to match new UX.